### PR TITLE
Hit production then sandbox

### DIFF
--- a/appstore/model.go
+++ b/appstore/model.go
@@ -112,4 +112,8 @@ type (
 		PendingRenewalInfo []PendingRenewalInfo `json:"pending_renewal_info"`
 		IsRetryable        bool                 `json:"is-retryable"`
 	}
+
+	HttpStatusResponse struct {
+		Status int `json:"status"`
+	}
 )

--- a/appstore/model.go
+++ b/appstore/model.go
@@ -112,8 +112,4 @@ type (
 		PendingRenewalInfo []PendingRenewalInfo `json:"pending_renewal_info"`
 		IsRetryable        bool                 `json:"is-retryable"`
 	}
-
-	HttpStatusResponse struct {
-		Status int `json:"status"`
-	}
 )


### PR DESCRIPTION
Merge https://github.com/wasedaigo/go-iap/pull/1 first

This change implements the Apple's recommended method (hit the production server before the sandbox). This eliminates the need of environment settings for development/production